### PR TITLE
Feature/#93/manualCICD/201724554

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,9 +39,7 @@ jobs:
       - name: make application.yml
         run: |
           chmod 755 appspec.yml
-          cd src/main
-          mkdir resources
-          cd resources
+          cd src/main/resources
           touch application.yml
           echo "${{ secrets.APPLICATION_YML }}" > application.yml
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,8 +44,7 @@ jobs:
           cd resources
           touch application.yml
           echo "${{ secrets.APPLICATION_YML }}" > application.yml
-          touch logback-spring.xml
-          echo "${{ secrets.LOGBACK_SPRING_XML }}" > logback-spring.xml
+
         shell: bash
 
       - name: archive project

--- a/.gitignore
+++ b/.gitignore
@@ -201,4 +201,3 @@ README.html
 .exercism
 
 /src/main/resources/application.yml
-/src/main/resources/logback-spring.xml

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-uri"/>
+    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} - %-5le %logger{35} : %msg%n</pattern>
+        </layout>
+        <username>서버 관제</username>
+        <iconEmoji>:hammer_and_wrench:</iconEmoji>
+        <colorCoding>true</colorCoding>
+    </appender>
+
+    <!-- Consol appender 설정 -->
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="ASYNC_SLACK"/>
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## slack으로 에러 로그 조회 기능 구현
* 발생한 문제
  * logback-spring.xml 파일이 secret으로 제대로 작성되지 않던 문제
* 해결 방법
  * secret을 이용해 "echo > 파일" 의 방법은 ""와 ${}에 포함된 값이 입력되지 않음 -> yml만 secret을 이용하고 logback은 github에 실제로 push 