### PR TITLE
E-Class 차트 생성 버그 수정, 테이블 수정

### DIFF
--- a/src/main/java/com/example/demo/datacontrol/datachart/domain/entity/CustomDataChartProperties.java
+++ b/src/main/java/com/example/demo/datacontrol/datachart/domain/entity/CustomDataChartProperties.java
@@ -2,6 +2,7 @@ package com.example.demo.datacontrol.datachart.domain.entity;
 
 import com.example.demo.datacontrol.datachart.domain.types.Axis;
 import com.example.demo.datacontrol.datachart.domain.types.AxisType;
+import com.example.demo.datacontrol.datachart.domain.types.ChartType;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 
@@ -20,6 +21,8 @@ public class CustomDataChartProperties {
     private Float minimumValue;
     private Float maximumValue;
     private Float stepSize;
+    @Enumerated(EnumType.STRING)
+    private ChartType chartType;
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     private CustomDataChart customDataChart;

--- a/src/main/java/com/example/demo/datacontrol/datachart/domain/types/ChartLabelPosition.java
+++ b/src/main/java/com/example/demo/datacontrol/datachart/domain/types/ChartLabelPosition.java
@@ -1,5 +1,5 @@
 package com.example.demo.datacontrol.datachart.domain.types;
 
 public enum ChartLabelPosition {
-    END, START, CENTER
+    END, START, CENTER, NONE
 }

--- a/src/main/java/com/example/demo/datacontrol/datachart/domain/types/ChartLegendPosition.java
+++ b/src/main/java/com/example/demo/datacontrol/datachart/domain/types/ChartLegendPosition.java
@@ -1,5 +1,5 @@
 package com.example.demo.datacontrol.datachart.domain.types;
 
 public enum ChartLegendPosition {
-    TOP, BOTTOM, LEFT, RIGHT
+    TOP, BOTTOM, LEFT, RIGHT, NONE
 }

--- a/src/main/java/com/example/demo/datacontrol/datachart/service/CustomDataChartService.java
+++ b/src/main/java/com/example/demo/datacontrol/datachart/service/CustomDataChartService.java
@@ -27,7 +27,7 @@ public class CustomDataChartService {
     private final CustomDataRepository customDataRepository;
 
     @Transactional
-    public void createCustomDataChart(CustomDataChart customDataChart, String username){
+    public CustomDataChart createCustomDataChart(CustomDataChart customDataChart, String username){
         Optional<User> user = userRepository.findByUsername(username);
 
         Optional<CustomDataChart> findCustomDataChart = customDataChartRepository.findByClassIdAndChapterIdAndSequenceIdAndOwnerAndTitle(
@@ -45,6 +45,7 @@ public class CustomDataChartService {
         }
 
         customDataChartRepository.save(customDataChart);
+        return customDataChart;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/demo/datacontrol/dataclassroom/domain/entity/classroomsequencechunk/ClassroomSequenceChunk.java
+++ b/src/main/java/com/example/demo/datacontrol/dataclassroom/domain/entity/classroomsequencechunk/ClassroomSequenceChunk.java
@@ -42,9 +42,9 @@ public class ClassroomSequenceChunk {
     private String url;
 
     // 표
-    @Lob
+    @Transient
     private String properties;
-    @Lob
+    @Transient
     private String data;
 
     // 차트
@@ -64,6 +64,10 @@ public class ClassroomSequenceChunk {
     private UUID uuid;
     @Transient
     private List<CustomDataChartProperties> axisProperties = new ArrayList<>();
+
+    public void updateCustomDataChart(CustomDataChart customDataChart) {
+        this.customDataChart = customDataChart;
+    }
 
     public ClassroomSequenceChunk(ClassroomSequence classroomSequence, ClassroomSequenceType classroomSequenceType, Boolean studentVisibleStatus, String title, String content, String url, String properties, String data) {
         this.classroomSequence = classroomSequence;

--- a/src/main/java/com/example/demo/datacontrol/dataclassroom/domain/entity/classroomsequencechunk/ClassroomSequenceChunk.java
+++ b/src/main/java/com/example/demo/datacontrol/dataclassroom/domain/entity/classroomsequencechunk/ClassroomSequenceChunk.java
@@ -42,7 +42,9 @@ public class ClassroomSequenceChunk {
     private String url;
 
     // 표
+    @Transient
     private String properties;
+    @Transient
     private String data;
 
     // 차트

--- a/src/main/java/com/example/demo/datacontrol/dataclassroom/domain/entity/classroomsequencechunk/ClassroomSequenceChunk.java
+++ b/src/main/java/com/example/demo/datacontrol/dataclassroom/domain/entity/classroomsequencechunk/ClassroomSequenceChunk.java
@@ -42,9 +42,9 @@ public class ClassroomSequenceChunk {
     private String url;
 
     // 표
-    @Transient
+    @Lob
     private String properties;
-    @Transient
+    @Lob
     private String data;
 
     // 차트

--- a/src/main/java/com/example/demo/datacontrol/dataclassroom/service/ClassroomService.java
+++ b/src/main/java/com/example/demo/datacontrol/dataclassroom/service/ClassroomService.java
@@ -104,7 +104,6 @@ public class ClassroomService {
                         customDataForChartList.add(new CustomDataDto(CustomDataDto.parseStringToProperties(chunk.getProperties()), CustomDataDto.parseStringToData(chunk.getData()), null, null, LocalDateTime.now(), null, user.get(), null, null, null, false));
                         target_uuid = UUID.fromString("00000000-0000-0000-0000-000000000111");
                     }
-
                     customDataCharts.add(new CustomDataChart(chunk.getTitle(), chunk.getLegendPosition(), chunk.getLabelPosition(),
                             user.get(), username, null, null, null, chunk.getChartType(), target_uuid, true,
                             chunk.getAxisProperties()));
@@ -128,10 +127,17 @@ public class ClassroomService {
                         c.updateUuid(dataLiteracyService.uploadCustomData(customDataForChartList.get(index), username));
                     }
                 }
+                // todo : 버그 있는데 차트 2개 입력해도 1개 저장됨
+                CustomDataChart customDataChartSaved = customDataChartService.createCustomDataChart(c, username);
+                for (ClassroomSequenceChunk chunk : save.getClassroomChapters().get(0).getClassroomSequences().get(i).getSequenceChunks()) {
+                    if (chunk.getClassroomSequenceType().equals(ClassroomSequenceType.CHART)) {
+                        chunk.updateCustomDataChart(customDataChartSaved);
+                    }
+                }
+
                 index += 1;
             }
-            // todo : 버그 있는데 차트 2개 입력해도 1개 저장됨
-            customDataChartService.createCustomDataChart(c, username);
+
         }
         for (CustomDataDto c : customDatas) {
             // CustomData 저장

--- a/src/main/java/com/example/demo/datacontrol/dataliteracy/model/dto/CustomDataDto.java
+++ b/src/main/java/com/example/demo/datacontrol/dataliteracy/model/dto/CustomDataDto.java
@@ -44,7 +44,7 @@ public class CustomDataDto {
         List<String> resultList = new ArrayList<>();
 
         // Remove the outer brackets and split by ', ' to get individual elements
-        String[] elements = input.substring(1, input.length() - 1).split(", ");
+        String[] elements = input.substring(1, input.length() - 1).replaceAll(",", ", ").split(", ");
 
         for (String element : elements) {
             // Remove any leading or trailing whitespace
@@ -59,12 +59,12 @@ public class CustomDataDto {
         List<List<String>> resultList = new ArrayList<>();
 
         // Remove the outer brackets and split by "], [" to get individual lists
-        String[] lists = input.substring(2, input.length() - 2).split("\\], \\[");
+        String[] lists = input.substring(2, input.length() - 2).split("\\], \\[|\\],\\[");
 
         for (String list : lists) {
             List<String> innerList = new ArrayList<>();
             // Split each inner list by ", " to get individual elements
-            String[] elements = list.split(", ");
+            String[] elements = list.replaceAll(",", ", ").split(", ");
             for (String element : elements) {
                 // Remove any leading or trailing whitespace and brackets
                 element = element.trim().replaceAll("[\\[\\]]", "");


### PR DESCRIPTION
1. E-Class 생성 시 longtext 에러로 넣지 못하는 에러 픽스, 데이터 배열에서 공백없는 부분 일관성 있게 해결

2. Data, Properties 등록되지 않게 최종변경, E-Class에 CustomData 외래키로 등록되게 변경

3. Chart 부분 LabelPosition, LegendPostition "NONE" 상태 추가, CustomDataChartProperties에 ChartType 추가





